### PR TITLE
Add --variable option

### DIFF
--- a/docs/_docs/lookup-locations/variables.md
+++ b/docs/_docs/lookup-locations/variables.md
@@ -5,12 +5,35 @@ nav_order: 52
 
 ## Simple Locations
 
-By design, [Shared Variables]({% link _docs/configs/shared-variables.md %}) they have a very simple lookup logic. Examples:
+By design, [Shared Variables]({% link _docs/configs/shared-variables.md %}) they have a very simple lookup logic. The lookup locations are simple because variables are so powerful and affect templates at compile-time.
+
+The general lookup locations are:
 
     configs/BLUEPRINT/variables/base.rb
     configs/BLUEPRINT/variables/development.rb
     configs/BLUEPRINT/variables/production.rb
 
-The lookup locations are simple because variables are so powerful and affect templates at compile-time.
+## Examples
+
+If you use:
+
+    LONO_ENV=production lono cfn deploy demo
+
+Then lono will use:
+
+    configs/demo/variables/production.rb
+
+## Specify Lookup Location
+
+You can use the `--variable` option to override the default lookup behavior.  Example:
+
+    lono cfn deploy --variable configs/ec2/variables/dev.rb
+    lono cfn deploy --variable dev # same as configs/ec2/variables/dev.rb
+
+## Always Used: base.rb
+
+If `base.rb` exists, it will always be loaded first as part of [Layering]({% link _docs/layering/variables.md %}).
+
+    configs/BLUEPRINT/variables/base.rb
 
 {% include prev_next.md %}

--- a/lib/lono/cfn.rb
+++ b/lib/lono/cfn.rb
@@ -4,15 +4,16 @@ module Lono
     class_option :noop, type: :boolean
 
     base_options = Proc.new do
-      # common to create and update
+      # common to create, update and deploy
       option :blueprint, desc: "override convention and specify the template file to use"
-      option :template, desc: "override convention and specify the template file to use"
-      option :param, desc: "override convention and specify the param file to use"
-      option :lono, type: :boolean, desc: "invoke lono to generate CloudFormation templates", default: true
       option :capabilities, type: :array, desc: "iam capabilities. Ex: CAPABILITY_IAM, CAPABILITY_NAMED_IAM"
       option :iam, type: :boolean, desc: "Shortcut for common IAM capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM"
+      option :lono, type: :boolean, desc: "invoke lono to generate CloudFormation templates", default: true
+      option :param, desc: "override convention and specify the param file to use"
       option :rollback, type: :boolean, desc: "rollback", default: true
       option :tags, type: :hash, desc: "Tags for the stack. IE: name:api-web owner:bob"
+      option :template, desc: "override convention and specify the template file to use"
+      option :variables, desc: "override convention and specify the variables file to use"
     end
     wait_option = Proc.new do
       option :wait, type: :boolean, desc: "Wait for stack operation to complete.", default: true

--- a/lib/lono/cfn.rb
+++ b/lib/lono/cfn.rb
@@ -13,7 +13,7 @@ module Lono
       option :rollback, type: :boolean, desc: "rollback", default: true
       option :tags, type: :hash, desc: "Tags for the stack. IE: name:api-web owner:bob"
       option :template, desc: "override convention and specify the template file to use"
-      option :variables, desc: "override convention and specify the variables file to use"
+      option :variable, desc: "override convention and specify the variable file to use"
     end
     wait_option = Proc.new do
       option :wait, type: :boolean, desc: "Wait for stack operation to complete.", default: true

--- a/lib/lono/param/generator.rb
+++ b/lib/lono/param/generator.rb
@@ -37,7 +37,7 @@ class Lono::Param
       medium_form = "#{root}/configs/#{@blueprint}/params/#{env}/#{@param}"
       short_form = "#{root}/configs/#{@blueprint}/params/#{env}"
 
-      if ENV['LONO_PARAM_DEBUG']
+      if ENV['LONO_DEBUG_PARAM']
         puts "Lono.blueprint_root #{Lono.blueprint_root}"
         puts "direct_absolute_form #{direct_absolute_form}"
         puts "direct_relative_form #{direct_relative_form}"
@@ -87,7 +87,7 @@ class Lono::Param
       @base_path = lookup_param_file(env: "base")
       @env_path = lookup_param_file(env: Lono.env)
 
-      if ENV['LONO_PARAM_DEBUG']
+      if ENV['LONO_DEBUG_PARAM']
         puts "  @base_path #{@base_path.inspect}"
         puts "  @env_path #{@env_path.inspect}"
       end

--- a/lib/lono/template/context/loader.rb
+++ b/lib/lono/template/context/loader.rb
@@ -11,7 +11,7 @@ class Lono::Template::Context
       load_variables_file(project_path("base"))
 
       direct_absolute_form = @options[:variable] # user provided the absolute full path
-      direct_relative_form = "#{Lono.root}/#{@options[:variable]}" # user provided the full path within the lono project
+      direct_relative_form = "#{Lono.root}/configs/#{@blueprint}/variables/#{@options[:variable]}" # user provided the full path within the lono project
       conventional_form = project_path(Lono.env)
 
       if ENV['LONO_DEBUG_VARIABLE']
@@ -20,8 +20,8 @@ class Lono::Template::Context
         puts "conventional_form: #{conventional_form.inspect}"
       end
 
-      load_variables_file(direct_absolute_form) if variable_file?(direct_absolute_form)
-      load_variables_file(direct_relative_form) if variable_file?(direct_relative_form)
+      load_variables_file(variable_file(direct_absolute_form)) if variable_file?(direct_absolute_form)
+      load_variables_file(variable_file(direct_relative_form)) if variable_file?(direct_relative_form)
       load_variables_file(conventional_form) if variable_file?(conventional_form)
     end
 
@@ -29,6 +29,11 @@ class Lono::Template::Context
       return if path.nil?
       return path if File.file?(path) # direct lookup with .rb extension
       return "#{path}.rb" if File.file?("#{path}.rb") # direct lookup without .rb extension
+    end
+
+    def variable_file(path)
+      return path if File.file?(path)
+      return "#{path}.rb" if File.file?("#{path}.rb")
     end
 
     def project_path(name)

--- a/lib/lono/template/context/loader.rb
+++ b/lib/lono/template/context/loader.rb
@@ -8,14 +8,27 @@ class Lono::Template::Context
     #   config/variables/development.rb - will override any variables in base.rb
     #
     def load_variables
-      load_variables_file(blueprint_path("base"))
-      load_variables_file(blueprint_path(Lono.env))
       load_variables_file(project_path("base"))
-      load_variables_file(project_path(Lono.env))
+
+      direct_absolute_form = @options[:variable] # user provided the absolute full path
+      direct_relative_form = "#{Lono.root}/#{@options[:variable]}" # user provided the full path within the lono project
+      conventional_form = project_path(Lono.env)
+
+      if ENV['LONO_DEBUG_VARIABLE']
+        puts "direct_absolute_form: #{direct_absolute_form.inspect}"
+        puts "direct_relative_form: #{direct_relative_form.inspect}"
+        puts "conventional_form: #{conventional_form.inspect}"
+      end
+
+      load_variables_file(direct_absolute_form) if variable_file?(direct_absolute_form)
+      load_variables_file(direct_relative_form) if variable_file?(direct_relative_form)
+      load_variables_file(conventional_form) if variable_file?(conventional_form)
     end
 
-    def blueprint_path(name)
-      "#{Lono.blueprint_root}/config/variables/#{name}.rb"
+    def variable_file?(path)
+      return if path.nil?
+      return path if File.file?(path) # direct lookup with .rb extension
+      return "#{path}.rb" if File.file?("#{path}.rb") # direct lookup without .rb extension
     end
 
     def project_path(name)


### PR DESCRIPTION
Add `--variable` option to override variables lookup location if needed.  Example:

    lono cfn deploy demo --variable configs/demo/variables/my-var.rb
    lono cfn deploy demo --variable my-var # same as above