### PR TITLE
fix plan: upload template to s3

### DIFF
--- a/lib/lono/cfn/plan.rb
+++ b/lib/lono/cfn/plan.rb
@@ -10,6 +10,7 @@ module Lono::Cfn
     end
 
     def for_update
+      upload_all
       # Allow passing down of the build object from Cfn::Deploy so build.all only runs once.
       # Fallback to creating new build object but still pass one build object instance down.
       @options[:build] ||= build
@@ -24,11 +25,35 @@ module Lono::Cfn
     end
 
     def for_create
+      upload_all
       New.new(@options).run
     end
 
     def for_delete
       Delete.new(@options).run
     end
+
+    # important to call before for_update and for_create
+    # since changeset requires the template to already be uploaded to s3
+    def upload_all
+      upload_templates
+      upload_files
+    end
+
+    def upload_templates
+      Lono::Builder::Template::Upload.new(@options).run
+    end
+
+    # Upload files right before create_stack or execute_change_set
+    # Its better to upload here as part of a deploy vs a build
+    # IE: lono build should try not to do a remote write to s3 if possible
+    def upload_files
+      # Files built and compressed in
+      #     Lono::Builder::Dsl::Finalizer::Files::Build#build_files
+      Lono::Files.files.each do |file| # using singular file, but is like a "file_list"
+        file.upload
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix subtle bug with `lono plan`, cloudformation template is uploaded to s3 before plan.

## How to Test

Test `lono plan`

## Version Changes

Patch